### PR TITLE
Add three new endpoints for obstruction angle calculations

### DIFF
--- a/src/server/controllers/endpoint_controller.py
+++ b/src/server/controllers/endpoint_controller.py
@@ -1,6 +1,6 @@
 from typing import Dict, Any
 from ..interfaces import ILogger
-from ..services.remote_service import ColorManageService, DaylightService, DFEvalService
+from ..services.remote_service import ColorManageService, DaylightService, DFEvalService, ObstructionService
 from ..services.orchestration import OrchestrationService
 
 
@@ -12,12 +12,14 @@ class EndpointController:
         colormanage_service: ColorManageService,
         daylight_service: DaylightService,
         df_eval_service: DFEvalService,
+        obstruction_service: ObstructionService,
         orchestration_service: OrchestrationService,
         logger: ILogger
     ):
         self._colormanage = colormanage_service
         self._daylight = daylight_service
         self._df_eval = df_eval_service
+        self._obstruction = obstruction_service
         self._orchestration = orchestration_service
         self._logger = logger
 
@@ -57,3 +59,75 @@ class EndpointController:
         """Handle get_df_rgb endpoint (orchestrates get_df + to_rgb) with file upload"""
         self._logger.info("Processing get_df_rgb request with file upload")
         return self._orchestration.get_df_rgb(file, form_data)
+
+    def horizon_angle(self, request_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle horizon_angle endpoint"""
+        self._logger.info("Processing horizon_angle request")
+
+        # Validate required fields
+        required_fields = ["x", "y", "z", "rad_x", "rad_y", "mesh"]
+        for field in required_fields:
+            if field not in request_data:
+                return {"status": "error", "error": f"Missing required field: {field}"}
+
+        # Validate mesh data
+        mesh = request_data.get("mesh")
+        if not isinstance(mesh, list) or len(mesh) < 3:
+            return {"status": "error", "error": "Mesh must contain at least 3 points"}
+
+        return self._obstruction.calculate_horizon_angle(
+            x=request_data["x"],
+            y=request_data["y"],
+            z=request_data["z"],
+            rad_x=request_data["rad_x"],
+            rad_y=request_data["rad_y"],
+            mesh=mesh
+        )
+
+    def zenith_angle(self, request_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle zenith_angle endpoint"""
+        self._logger.info("Processing zenith_angle request")
+
+        # Validate required fields
+        required_fields = ["x", "y", "z", "rad_x", "rad_y", "mesh"]
+        for field in required_fields:
+            if field not in request_data:
+                return {"status": "error", "error": f"Missing required field: {field}"}
+
+        # Validate mesh data
+        mesh = request_data.get("mesh")
+        if not isinstance(mesh, list) or len(mesh) < 3:
+            return {"status": "error", "error": "Mesh must contain at least 3 points"}
+
+        return self._obstruction.calculate_zenith_angle(
+            x=request_data["x"],
+            y=request_data["y"],
+            z=request_data["z"],
+            rad_x=request_data["rad_x"],
+            rad_y=request_data["rad_y"],
+            mesh=mesh
+        )
+
+    def obstruction(self, request_data: Dict[str, Any]) -> Dict[str, Any]:
+        """Handle obstruction endpoint (calculates both horizon and zenith angles)"""
+        self._logger.info("Processing obstruction request")
+
+        # Validate required fields
+        required_fields = ["x", "y", "z", "rad_x", "rad_y", "mesh"]
+        for field in required_fields:
+            if field not in request_data:
+                return {"status": "error", "error": f"Missing required field: {field}"}
+
+        # Validate mesh data
+        mesh = request_data.get("mesh")
+        if not isinstance(mesh, list) or len(mesh) < 3:
+            return {"status": "error", "error": "Mesh must contain at least 3 points"}
+
+        return self._obstruction.calculate_obstruction(
+            x=request_data["x"],
+            y=request_data["y"],
+            z=request_data["z"],
+            rad_x=request_data["rad_x"],
+            rad_y=request_data["rad_y"],
+            mesh=mesh
+        )

--- a/src/server/enums.py
+++ b/src/server/enums.py
@@ -44,9 +44,13 @@ class EndpointType(Enum):
     GET_DF = "get_df"
     GET_STATS = "get_stats"
     GET_DF_RGB = "get_df_rgb"
+    HORIZON_ANGLE = "horizon_angle"
+    ZENITH_ANGLE = "zenith_angle"
+    OBSTRUCTION = "obstruction"
 
 
 class ServiceURL(Enum):
     COLORMANAGE = "https://colormanage-server-jia3y72oka-ma.a.run.app"
     DAYLIGHT = "https://daylight-processing-jia3y72oka-ma.a.run.app"
     DF_EVAL = "https://df-eval-server-jia3y72oka-ma.a.run.app"
+    OBSTRUCTION = "https://obstruction-server-182483330095.europe-north2.run.app"

--- a/src/server/services/remote_service.py
+++ b/src/server/services/remote_service.py
@@ -74,3 +74,49 @@ class DFEvalService(RemoteService):
     def get_stats(self, **kwargs) -> Dict[str, Any]:
         """Get statistics from DF evaluation service"""
         return self.call(f"/{EndpointType.GET_STATS.value}", kwargs)
+
+
+class ObstructionService(RemoteService):
+    """Service for obstruction angle calculations"""
+
+    def __init__(self, http_client: IHTTPClient, logger: ILogger):
+        super().__init__(ServiceURL.OBSTRUCTION, http_client, logger)
+
+    def calculate_horizon_angle(self, x: float, y: float, z: float,
+                               rad_x: float, rad_y: float, mesh: list) -> Dict[str, Any]:
+        """Calculate horizon angle from window position"""
+        request_data = {
+            "x": x,
+            "y": y,
+            "z": z,
+            "rad_x": rad_x,
+            "rad_y": rad_y,
+            "mesh": mesh
+        }
+        return self.call(f"/{EndpointType.HORIZON_ANGLE.value}", request_data)
+
+    def calculate_zenith_angle(self, x: float, y: float, z: float,
+                              rad_x: float, rad_y: float, mesh: list) -> Dict[str, Any]:
+        """Calculate zenith angle from window position"""
+        request_data = {
+            "x": x,
+            "y": y,
+            "z": z,
+            "rad_x": rad_x,
+            "rad_y": rad_y,
+            "mesh": mesh
+        }
+        return self.call(f"/{EndpointType.ZENITH_ANGLE.value}", request_data)
+
+    def calculate_obstruction(self, x: float, y: float, z: float,
+                            rad_x: float, rad_y: float, mesh: list) -> Dict[str, Any]:
+        """Calculate both horizon and zenith angles from window position"""
+        request_data = {
+            "x": x,
+            "y": y,
+            "z": z,
+            "rad_x": rad_x,
+            "rad_y": rad_y,
+            "mesh": mesh
+        }
+        return self.call(f"/{EndpointType.OBSTRUCTION.value}", request_data)


### PR DESCRIPTION
- Added OBSTRUCTION service URL to ServiceURL enum
- Created ObstructionService class for horizon/zenith angle calculations
- Added three new endpoints: /horizon_angle, /zenith_angle, /obstruction
- Implemented request validation for required fields (x, y, z, rad_x, rad_y, mesh)
- All endpoints proxy requests to external obstruction calculation service
- Follows existing OOP patterns and architecture (RemoteService, EndpointController)

The endpoints accept window position coordinates (x, y, z), rotation angles (rad_x, rad_y), and a mesh array of 3D points representing obstructions.