### PR TITLE
feat: split mesh support + simplified obstruction contracts

### DIFF
--- a/src/server/controllers/field_map.py
+++ b/src/server/controllers/field_map.py
@@ -6,11 +6,11 @@ class FieldMap(StandardMap):
 
     _content = {
         EndpointType.SIMULATE: [],
-        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
-        EndpointType.OBSTRUCTION: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.DIRECTION_ANGLE],
-        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
-        EndpointType.OBSTRUCTION_MULTI: [RequestField.X, RequestField.Y, RequestField.Z],
-        EndpointType.OBSTRUCTION_PARALLEL: [RequestField.X, RequestField.Y, RequestField.Z],
+        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.PARAMETERS, RequestField.MESH],
+        EndpointType.OBSTRUCTION: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.DIRECTION_ANGLE, RequestField.MESH],
+        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS, RequestField.MESH],
+        EndpointType.OBSTRUCTION_MULTI: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.MESH],
+        EndpointType.OBSTRUCTION_PARALLEL: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.MESH],
         EndpointType.CALCULATE_DIRECTION: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.REFERENCE_POINT: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.ENCODE: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],

--- a/src/server/controllers/field_map.py
+++ b/src/server/controllers/field_map.py
@@ -6,14 +6,14 @@ class FieldMap(StandardMap):
 
     _content = {
         EndpointType.SIMULATE: [],
-        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.MESH, RequestField.PARAMETERS],
+        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
         EndpointType.OBSTRUCTION: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.DIRECTION_ANGLE],
-        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS, RequestField.MESH],
+        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.OBSTRUCTION_MULTI: [RequestField.X, RequestField.Y, RequestField.Z],
         EndpointType.OBSTRUCTION_PARALLEL: [RequestField.X, RequestField.Y, RequestField.Z],
         EndpointType.CALCULATE_DIRECTION: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.REFERENCE_POINT: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
-        EndpointType.ENCODE: [RequestField.MODEL_TYPE, RequestField.MESH, RequestField.PARAMETERS],
+        EndpointType.ENCODE: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
         EndpointType.ENCODE_RAW: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
         EndpointType.HORIZON: [],
         EndpointType.ZENITH: [],

--- a/src/server/enums.py
+++ b/src/server/enums.py
@@ -190,8 +190,9 @@ class RequestField(Enum):
     Z2 = "z2"
 
     # Obstruction fields
-
     MESH = "mesh"
+    HORIZON_MESH = "horizon_mesh"
+    ZENITH_MESH = "zenith_mesh"
     DIRECTION_ANGLE = "direction_angle"
     START_ANGLE = "start_angle"
     END_ANGLE = "end_angle"

--- a/src/server/enums.py
+++ b/src/server/enums.py
@@ -191,8 +191,6 @@ class RequestField(Enum):
 
     # Obstruction fields
     MESH = "mesh"
-    HORIZON_MESH = "horizon_mesh"
-    ZENITH_MESH = "zenith_mesh"
     DIRECTION_ANGLE = "direction_angle"
     START_ANGLE = "start_angle"
     END_ANGLE = "end_angle"

--- a/src/server/services/orchestration/request_builder.py
+++ b/src/server/services/orchestration/request_builder.py
@@ -15,8 +15,19 @@ class WindowRequestBuilder:
         return self
 
     def with_mesh(self, mesh: Any) -> 'WindowRequestBuilder':
+        """Set legacy single mesh (backward compatibility)."""
         if mesh is not None:
             self._request[RequestField.MESH.value] = mesh
+        return self
+
+    def with_horizon_mesh(self, horizon_mesh: Any) -> 'WindowRequestBuilder':
+        if horizon_mesh is not None:
+            self._request[RequestField.HORIZON_MESH.value] = horizon_mesh
+        return self
+
+    def with_zenith_mesh(self, zenith_mesh: Any) -> 'WindowRequestBuilder':
+        if zenith_mesh is not None:
+            self._request[RequestField.ZENITH_MESH.value] = zenith_mesh
         return self
 
     def with_window(self, window_name: str, window_data: Any) -> 'WindowRequestBuilder':
@@ -64,15 +75,17 @@ class WindowRequestBuilder:
         """
         params = request_data.get(RequestField.PARAMETERS.value, {})
 
-        # Build the base request
-        built_request = (WindowRequestBuilder()
+        # Build the base request (supports split meshes or legacy single mesh)
+        builder = (WindowRequestBuilder()
                 .with_model_type(request_data.get(RequestField.MODEL_TYPE.value))
+                .with_horizon_mesh(request_data.get(RequestField.HORIZON_MESH.value))
+                .with_zenith_mesh(request_data.get(RequestField.ZENITH_MESH.value))
                 .with_mesh(request_data.get(RequestField.MESH.value))
                 .with_window(window_name, window_data)
                 .with_room_polygon(params.get(RequestField.ROOM_POLYGON.value))
                 .with_roof_height(params.get(RequestField.ROOF_HEIGHT.value))
-                .with_floor_height(params.get(RequestField.FLOOR_HEIGHT.value))
-                .build())
+                .with_floor_height(params.get(RequestField.FLOOR_HEIGHT.value)))
+        built_request = builder.build()
 
         # Extract horizon and zenith from window_data if they exist
         # This allows per-window obstruction data to skip the obstruction service

--- a/src/server/services/orchestration/request_builder.py
+++ b/src/server/services/orchestration/request_builder.py
@@ -15,19 +15,9 @@ class WindowRequestBuilder:
         return self
 
     def with_mesh(self, mesh: Any) -> 'WindowRequestBuilder':
-        """Set legacy single mesh (backward compatibility)."""
+        """Set mesh data (nested format: {"horizon": [...], "zenith": [...]})."""
         if mesh is not None:
             self._request[RequestField.MESH.value] = mesh
-        return self
-
-    def with_horizon_mesh(self, horizon_mesh: Any) -> 'WindowRequestBuilder':
-        if horizon_mesh is not None:
-            self._request[RequestField.HORIZON_MESH.value] = horizon_mesh
-        return self
-
-    def with_zenith_mesh(self, zenith_mesh: Any) -> 'WindowRequestBuilder':
-        if zenith_mesh is not None:
-            self._request[RequestField.ZENITH_MESH.value] = zenith_mesh
         return self
 
     def with_window(self, window_name: str, window_data: Any) -> 'WindowRequestBuilder':
@@ -75,11 +65,8 @@ class WindowRequestBuilder:
         """
         params = request_data.get(RequestField.PARAMETERS.value, {})
 
-        # Build the base request (supports split meshes or legacy single mesh)
         builder = (WindowRequestBuilder()
                 .with_model_type(request_data.get(RequestField.MODEL_TYPE.value))
-                .with_horizon_mesh(request_data.get(RequestField.HORIZON_MESH.value))
-                .with_zenith_mesh(request_data.get(RequestField.ZENITH_MESH.value))
                 .with_mesh(request_data.get(RequestField.MESH.value))
                 .with_window(window_name, window_data)
                 .with_room_polygon(params.get(RequestField.ROOM_POLYGON.value))

--- a/src/server/services/remote/contracts/obstruction_contracts.py
+++ b/src/server/services/remote/contracts/obstruction_contracts.py
@@ -73,20 +73,17 @@ class ObstructionRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        base = {
+        # Obstruction service only understands 'mesh' - combine split meshes if present
+        combined_mesh = self.mesh
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
+        return {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
+            RequestField.MESH.value: combined_mesh,
         }
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            if self.horizon_mesh is not None:
-                base[RequestField.HORIZON_MESH.value] = self.horizon_mesh
-            if self.zenith_mesh is not None:
-                base[RequestField.ZENITH_MESH.value] = self.zenith_mesh
-        else:
-            base[RequestField.MESH.value] = self.mesh
-        return base
 
 
 @dataclass
@@ -109,21 +106,16 @@ class ObstructionMultiRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        mesh_fields = {}
+        combined_mesh = self.mesh
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            if self.horizon_mesh is not None:
-                mesh_fields[RequestField.HORIZON_MESH.value] = self.horizon_mesh
-            if self.zenith_mesh is not None:
-                mesh_fields[RequestField.ZENITH_MESH.value] = self.zenith_mesh
-        else:
-            mesh_fields[RequestField.MESH.value] = self.mesh
+            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
         return self._build_dict(
             **{
                 RequestField.X.value: self.x,
                 RequestField.Y.value: self.y,
                 RequestField.Z.value: self.z,
                 RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-                **mesh_fields,
+                RequestField.MESH.value: combined_mesh,
                 RequestField.START_ANGLE.value: self.start_angle,
                 RequestField.END_ANGLE.value: self.end_angle,
                 RequestField.NUM_DIRECTIONS.value: self.num_directions
@@ -148,20 +140,16 @@ class ObstructionParallelRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        base = {
+        combined_mesh = self.mesh
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
+        return {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
+            RequestField.MESH.value: combined_mesh,
         }
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            if self.horizon_mesh is not None:
-                base[RequestField.HORIZON_MESH.value] = self.horizon_mesh
-            if self.zenith_mesh is not None:
-                base[RequestField.ZENITH_MESH.value] = self.zenith_mesh
-        else:
-            base[RequestField.MESH.value] = self.mesh
-        return base
 
 
 @dataclass

--- a/src/server/services/remote/contracts/obstruction_contracts.py
+++ b/src/server/services/remote/contracts/obstruction_contracts.py
@@ -35,8 +35,16 @@ class ObstructionRequest(RemoteServiceRequest):
         Returns:
             List of ObstructionRequest instances (one per window)
         """
-        horizon_mesh = content.get(RequestField.HORIZON_MESH.value)
-        zenith_mesh = content.get(RequestField.ZENITH_MESH.value)
+        # Extract meshes from nested format: {"mesh": {"horizon": [...], "zenith": [...]}}
+        mesh_data = content.get(RequestField.MESH.value, {})
+        if isinstance(mesh_data, dict):
+            horizon_mesh = mesh_data.get("horizon")
+            zenith_mesh = mesh_data.get("zenith")
+            mesh = []
+        else:
+            horizon_mesh = None
+            zenith_mesh = None
+            mesh = mesh_data
 
         # Check if this is a simple single-window request
         if RequestField.X.value in content:
@@ -45,7 +53,7 @@ class ObstructionRequest(RemoteServiceRequest):
                 y=content.get(RequestField.Y.value, 0.0),
                 z=content.get(RequestField.Z.value, 0.0),
                 direction_angle=content.get(RequestField.DIRECTION_ANGLE.value, 0.0),
-                mesh=content.get(RequestField.MESH.value, []),
+                mesh=mesh,
                 horizon_mesh=horizon_mesh,
                 zenith_mesh=zenith_mesh,
             )]
@@ -53,7 +61,6 @@ class ObstructionRequest(RemoteServiceRequest):
         # Otherwise, extract from reference_point and direction_angle responses
         reference_points = content.get(RequestField.REFERENCE_POINT.value, {})
         direction_angles = content.get(RequestField.DIRECTION_ANGLE.value, {})
-        mesh = content.get(RequestField.MESH.value, [])
 
         requests = []
         for window_name, ref_point in reference_points.items():
@@ -73,17 +80,20 @@ class ObstructionRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        # Obstruction service only understands 'mesh' - combine split meshes if present
-        combined_mesh = self.mesh
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
-        return {
+        result = {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-            RequestField.MESH.value: combined_mesh,
         }
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            result[RequestField.MESH.value] = {
+                "horizon": self.horizon_mesh or [],
+                "zenith": self.zenith_mesh or [],
+            }
+        else:
+            result[RequestField.MESH.value] = self.mesh
+        return result
 
 
 @dataclass
@@ -106,16 +116,17 @@ class ObstructionMultiRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        combined_mesh = self.mesh
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
+            mesh_value = {"horizon": self.horizon_mesh or [], "zenith": self.zenith_mesh or []}
+        else:
+            mesh_value = self.mesh
         return self._build_dict(
             **{
                 RequestField.X.value: self.x,
                 RequestField.Y.value: self.y,
                 RequestField.Z.value: self.z,
                 RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-                RequestField.MESH.value: combined_mesh,
+                RequestField.MESH.value: mesh_value,
                 RequestField.START_ANGLE.value: self.start_angle,
                 RequestField.END_ANGLE.value: self.end_angle,
                 RequestField.NUM_DIRECTIONS.value: self.num_directions
@@ -140,16 +151,20 @@ class ObstructionParallelRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        combined_mesh = self.mesh
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
-        return {
+        result = {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-            RequestField.MESH.value: combined_mesh,
         }
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            result[RequestField.MESH.value] = {
+                "horizon": self.horizon_mesh or [],
+                "zenith": self.zenith_mesh or [],
+            }
+        else:
+            result[RequestField.MESH.value] = self.mesh
+        return result
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add split mesh support (horizon_mesh + zenith_mesh)
- Remove mesh from required fields for backward compatibility
- Simplify obstruction contracts for split mesh support

## Test plan
- [ ] Verify obstruction API accepts both single mesh and split mesh formats
- [ ] Test backward compatibility with existing clients