### PR TITLE
feat: Unified mesh support and debug mode

### DIFF
--- a/src/server/controllers/field_map.py
+++ b/src/server/controllers/field_map.py
@@ -6,11 +6,11 @@ class FieldMap(StandardMap):
 
     _content = {
         EndpointType.SIMULATE: [],
-        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
-        EndpointType.OBSTRUCTION: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.DIRECTION_ANGLE],
-        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
-        EndpointType.OBSTRUCTION_MULTI: [RequestField.X, RequestField.Y, RequestField.Z],
-        EndpointType.OBSTRUCTION_PARALLEL: [RequestField.X, RequestField.Y, RequestField.Z],
+        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.PARAMETERS, RequestField.MESH],
+        EndpointType.OBSTRUCTION: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.DIRECTION_ANGLE, RequestField.MESH],
+        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS, RequestField.MESH],
+        EndpointType.OBSTRUCTION_MULTI: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.MESH],
+        EndpointType.OBSTRUCTION_PARALLEL: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.MESH],
         EndpointType.CALCULATE_DIRECTION: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.REFERENCE_POINT: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.ENCODE: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],

--- a/src/server/controllers/field_map.py
+++ b/src/server/controllers/field_map.py
@@ -6,14 +6,14 @@ class FieldMap(StandardMap):
 
     _content = {
         EndpointType.SIMULATE: [],
-        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.MESH, RequestField.PARAMETERS],
+        EndpointType.RUN: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
         EndpointType.OBSTRUCTION: [RequestField.X, RequestField.Y, RequestField.Z, RequestField.DIRECTION_ANGLE],
-        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS, RequestField.MESH],
+        EndpointType.OBSTRUCTION_ALL: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.OBSTRUCTION_MULTI: [RequestField.X, RequestField.Y, RequestField.Z],
         EndpointType.OBSTRUCTION_PARALLEL: [RequestField.X, RequestField.Y, RequestField.Z],
         EndpointType.CALCULATE_DIRECTION: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
         EndpointType.REFERENCE_POINT: [RequestField.ROOM_POLYGON, RequestField.WINDOWS],
-        EndpointType.ENCODE: [RequestField.MODEL_TYPE, RequestField.MESH, RequestField.PARAMETERS],
+        EndpointType.ENCODE: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
         EndpointType.ENCODE_RAW: [RequestField.MODEL_TYPE, RequestField.PARAMETERS],
         EndpointType.HORIZON: [],
         EndpointType.ZENITH: [],

--- a/src/server/controllers/validation_strategy.py
+++ b/src/server/controllers/validation_strategy.py
@@ -56,7 +56,7 @@ class ValidationStrategy:
     # Map fields to their specific validators
     FIELD_VALIDATORS: Dict[RequestField, List[IFieldValidator]] = {
         RequestField.PARAMETERS: [PresenceValidator(), DictTypeValidator()],
-        RequestField.MESH: [PresenceValidator(), ListTypeValidator()],
+        RequestField.MESH: [PresenceValidator(), DictTypeValidator()],
     }
 
     @classmethod

--- a/src/server/controllers/validation_strategy.py
+++ b/src/server/controllers/validation_strategy.py
@@ -56,7 +56,7 @@ class ValidationStrategy:
     # Map fields to their specific validators
     FIELD_VALIDATORS: Dict[RequestField, List[IFieldValidator]] = {
         RequestField.PARAMETERS: [PresenceValidator(), DictTypeValidator()],
-        RequestField.MESH: [PresenceValidator(), DictTypeValidator()],
+        RequestField.MESH: [PresenceValidator()],  # Mesh accepts both dict and list formats
     }
 
     @classmethod

--- a/src/server/enums.py
+++ b/src/server/enums.py
@@ -190,8 +190,9 @@ class RequestField(Enum):
     Z2 = "z2"
 
     # Obstruction fields
-
     MESH = "mesh"
+    HORIZON_MESH = "horizon_mesh"
+    ZENITH_MESH = "zenith_mesh"
     DIRECTION_ANGLE = "direction_angle"
     START_ANGLE = "start_angle"
     END_ANGLE = "end_angle"

--- a/src/server/enums.py
+++ b/src/server/enums.py
@@ -191,8 +191,6 @@ class RequestField(Enum):
 
     # Obstruction fields
     MESH = "mesh"
-    HORIZON_MESH = "horizon_mesh"
-    ZENITH_MESH = "zenith_mesh"
     DIRECTION_ANGLE = "direction_angle"
     START_ANGLE = "start_angle"
     END_ANGLE = "end_angle"

--- a/src/server/enums.py
+++ b/src/server/enums.py
@@ -226,6 +226,9 @@ class RequestField(Enum):
     ROOF_HEIGHT = "height_roof_over_floor"
     FLOOR_HEIGHT = "floor_height_above_terrain"
 
+    # Debug flags
+    DEBUG_MODE = "debug_mode"
+
     # Optimization flags
     USE_EARLY_EXIT_OPTIMIZATION = "use_early_exit_optimization"
 

--- a/src/server/services/helpers/parameter_validator.py
+++ b/src/server/services/helpers/parameter_validator.py
@@ -55,8 +55,13 @@ class ParameterValidator:
         if result.get(ResponseKey.STATUS.value) == ResponseStatus.ERROR.value:
             return result
 
-        if not isinstance(mesh, list) or len(mesh) < MeshValidation.MIN_TRIANGLES:
-            return ValidationResponseBuilder.error(f"Mesh must be a list with at least {MeshValidation.MIN_TRIANGLES} points")
+        if not isinstance(mesh, dict):
+            return ValidationResponseBuilder.error("Mesh must be a dict with 'horizon' and 'zenith' keys")
+
+        for key in ("horizon", "zenith"):
+            sub_mesh = mesh.get(key)
+            if not isinstance(sub_mesh, list):
+                return ValidationResponseBuilder.error(f"Mesh '{key}' must be a list of vertices")
 
         return ValidationResponseBuilder.success()
 

--- a/src/server/services/helpers/parameter_validator.py
+++ b/src/server/services/helpers/parameter_validator.py
@@ -55,8 +55,12 @@ class ParameterValidator:
         if result.get(ResponseKey.STATUS.value) == ResponseStatus.ERROR.value:
             return result
 
+        # Accept flat list format (unified mesh) or dict format (split horizon/zenith)
+        if isinstance(mesh, list):
+            return ValidationResponseBuilder.success()
+
         if not isinstance(mesh, dict):
-            return ValidationResponseBuilder.error("Mesh must be a dict with 'horizon' and 'zenith' keys")
+            return ValidationResponseBuilder.error("Mesh must be a list of vertices or a dict with 'horizon' and 'zenith' keys")
 
         for field in (RequestField.HORIZON, RequestField.ZENITH):
             sub_mesh = mesh.get(field.value)

--- a/src/server/services/helpers/parameter_validator.py
+++ b/src/server/services/helpers/parameter_validator.py
@@ -58,10 +58,10 @@ class ParameterValidator:
         if not isinstance(mesh, dict):
             return ValidationResponseBuilder.error("Mesh must be a dict with 'horizon' and 'zenith' keys")
 
-        for key in ("horizon", "zenith"):
-            sub_mesh = mesh.get(key)
+        for field in (RequestField.HORIZON, RequestField.ZENITH):
+            sub_mesh = mesh.get(field.value)
             if not isinstance(sub_mesh, list):
-                return ValidationResponseBuilder.error(f"Mesh '{key}' must be a list of vertices")
+                return ValidationResponseBuilder.error(f"Mesh '{field.value}' must be a list of vertices")
 
         return ValidationResponseBuilder.success()
 

--- a/src/server/services/orchestration/encode_orchestration_service.py
+++ b/src/server/services/orchestration/encode_orchestration_service.py
@@ -99,7 +99,7 @@ class SimulationOrchestrator(IOrchestrator):
             for window_name, result_dict in window_results:
                 if isinstance(result_dict, dict):
                     debug_window_results[window_name] = {
-                        'result': result_dict.get(RequestField.RESULT.value, []),
+                        'result': result_dict.get(RequestField.SIMULATION.value, []),
                         'mask': result_dict.get(RequestField.MASK.value, [])
                     }
             response['window_results'] = debug_window_results

--- a/src/server/services/orchestration/encode_orchestration_service.py
+++ b/src/server/services/orchestration/encode_orchestration_service.py
@@ -48,7 +48,7 @@ class SimulationOrchestrator(IOrchestrator):
         merger_result = self._call_merger_service(merged_data, file)
 
         # Check if debug mode is enabled in request
-        debug_mode = request_data.get('debug_mode', False)
+        debug_mode = request_data.get(RequestField.DEBUG_MODE.value, False)
 
         return self._build_final_response(merger_result, window_results, debug_mode)
 
@@ -99,10 +99,10 @@ class SimulationOrchestrator(IOrchestrator):
             for window_name, result_dict in window_results:
                 if isinstance(result_dict, dict):
                     debug_window_results[window_name] = {
-                        'result': result_dict.get(RequestField.SIMULATION.value, []),
-                        'mask': result_dict.get(RequestField.MASK.value, [])
+                        RequestField.RESULT.value: result_dict.get(RequestField.SIMULATION.value, []),
+                        RequestField.MASK.value: result_dict.get(RequestField.MASK.value, [])
                     }
-            response['window_results'] = debug_window_results
+            response[ResponseKey.WINDOW_RESULTS.value] = debug_window_results
 
         return response
 

--- a/src/server/services/orchestration/request_builder.py
+++ b/src/server/services/orchestration/request_builder.py
@@ -15,8 +15,19 @@ class WindowRequestBuilder:
         return self
 
     def with_mesh(self, mesh: Any) -> 'WindowRequestBuilder':
+        """Set legacy single mesh (backward compatibility)."""
         if mesh is not None:
             self._request[RequestField.MESH.value] = mesh
+        return self
+
+    def with_horizon_mesh(self, horizon_mesh: Any) -> 'WindowRequestBuilder':
+        if horizon_mesh is not None:
+            self._request[RequestField.HORIZON_MESH.value] = horizon_mesh
+        return self
+
+    def with_zenith_mesh(self, zenith_mesh: Any) -> 'WindowRequestBuilder':
+        if zenith_mesh is not None:
+            self._request[RequestField.ZENITH_MESH.value] = zenith_mesh
         return self
 
     def with_window(self, window_name: str, window_data: Any) -> 'WindowRequestBuilder':
@@ -64,15 +75,17 @@ class WindowRequestBuilder:
         """
         params = request_data.get(RequestField.PARAMETERS.value, {})
 
-        # Build the base request
-        built_request = (WindowRequestBuilder()
+        # Build the base request (supports split meshes or legacy single mesh)
+        builder = (WindowRequestBuilder()
                 .with_model_type(request_data.get(RequestField.MODEL_TYPE.value))
+                .with_horizon_mesh(request_data.get(RequestField.HORIZON_MESH.value))
+                .with_zenith_mesh(request_data.get(RequestField.ZENITH_MESH.value))
                 .with_mesh(request_data.get(RequestField.MESH.value))
                 .with_window(window_name, window_data)
                 .with_room_polygon(params.get(RequestField.ROOM_POLYGON.value))
                 .with_roof_height(params.get(RequestField.ROOF_HEIGHT.value))
-                .with_floor_height(params.get(RequestField.FLOOR_HEIGHT.value))
-                .build())
+                .with_floor_height(params.get(RequestField.FLOOR_HEIGHT.value)))
+        built_request = builder.build()
 
         # Extract horizon and zenith from window_data if they exist
         # This allows per-window obstruction data to skip the obstruction service

--- a/src/server/services/orchestration/request_builder.py
+++ b/src/server/services/orchestration/request_builder.py
@@ -15,19 +15,9 @@ class WindowRequestBuilder:
         return self
 
     def with_mesh(self, mesh: Any) -> 'WindowRequestBuilder':
-        """Set legacy single mesh (backward compatibility)."""
+        """Set mesh data (nested format: {"horizon": [...], "zenith": [...]})."""
         if mesh is not None:
             self._request[RequestField.MESH.value] = mesh
-        return self
-
-    def with_horizon_mesh(self, horizon_mesh: Any) -> 'WindowRequestBuilder':
-        if horizon_mesh is not None:
-            self._request[RequestField.HORIZON_MESH.value] = horizon_mesh
-        return self
-
-    def with_zenith_mesh(self, zenith_mesh: Any) -> 'WindowRequestBuilder':
-        if zenith_mesh is not None:
-            self._request[RequestField.ZENITH_MESH.value] = zenith_mesh
         return self
 
     def with_window(self, window_name: str, window_data: Any) -> 'WindowRequestBuilder':
@@ -75,11 +65,8 @@ class WindowRequestBuilder:
         """
         params = request_data.get(RequestField.PARAMETERS.value, {})
 
-        # Build the base request (supports split meshes or legacy single mesh)
         builder = (WindowRequestBuilder()
                 .with_model_type(request_data.get(RequestField.MODEL_TYPE.value))
-                .with_horizon_mesh(request_data.get(RequestField.HORIZON_MESH.value))
-                .with_zenith_mesh(request_data.get(RequestField.ZENITH_MESH.value))
                 .with_mesh(request_data.get(RequestField.MESH.value))
                 .with_window(window_name, window_data)
                 .with_room_polygon(params.get(RequestField.ROOM_POLYGON.value))

--- a/src/server/services/remote/contracts/main_request_contract.py
+++ b/src/server/services/remote/contracts/main_request_contract.py
@@ -14,7 +14,7 @@ class MainRequest(RemoteServiceRequest):
     """
     model_type: str
     params: Parameters
-    mesh: list
+    mesh: dict
     result: Any = None
 
     @property

--- a/src/server/services/remote/contracts/main_request_contract.py
+++ b/src/server/services/remote/contracts/main_request_contract.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Union
 
 from .base_contracts import RemoteServiceRequest
 from .encoder_contracts import Parameters
@@ -11,10 +11,11 @@ class MainRequest(RemoteServiceRequest):
     """Request for main /simulate endpoint
 
     The primary external request that initiates the full simulation pipeline.
+    Mesh can be a dict {horizon: [...], zenith: [...]} or a flat list [[x,y,z], ...].
     """
     model_type: str
     params: Parameters
-    mesh: dict
+    mesh: Union[dict, list]
     result: Any = None
 
     @property

--- a/src/server/services/remote/contracts/obstruction_contracts.py
+++ b/src/server/services/remote/contracts/obstruction_contracts.py
@@ -73,20 +73,17 @@ class ObstructionRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        base = {
+        # Obstruction service only understands 'mesh' - combine split meshes if present
+        combined_mesh = self.mesh
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
+        return {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
+            RequestField.MESH.value: combined_mesh,
         }
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            if self.horizon_mesh is not None:
-                base[RequestField.HORIZON_MESH.value] = self.horizon_mesh
-            if self.zenith_mesh is not None:
-                base[RequestField.ZENITH_MESH.value] = self.zenith_mesh
-        else:
-            base[RequestField.MESH.value] = self.mesh
-        return base
 
 
 @dataclass
@@ -109,21 +106,16 @@ class ObstructionMultiRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        mesh_fields = {}
+        combined_mesh = self.mesh
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            if self.horizon_mesh is not None:
-                mesh_fields[RequestField.HORIZON_MESH.value] = self.horizon_mesh
-            if self.zenith_mesh is not None:
-                mesh_fields[RequestField.ZENITH_MESH.value] = self.zenith_mesh
-        else:
-            mesh_fields[RequestField.MESH.value] = self.mesh
+            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
         return self._build_dict(
             **{
                 RequestField.X.value: self.x,
                 RequestField.Y.value: self.y,
                 RequestField.Z.value: self.z,
                 RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-                **mesh_fields,
+                RequestField.MESH.value: combined_mesh,
                 RequestField.START_ANGLE.value: self.start_angle,
                 RequestField.END_ANGLE.value: self.end_angle,
                 RequestField.NUM_DIRECTIONS.value: self.num_directions
@@ -148,20 +140,16 @@ class ObstructionParallelRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        base = {
+        combined_mesh = self.mesh
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
+        return {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
+            RequestField.MESH.value: combined_mesh,
         }
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            if self.horizon_mesh is not None:
-                base[RequestField.HORIZON_MESH.value] = self.horizon_mesh
-            if self.zenith_mesh is not None:
-                base[RequestField.ZENITH_MESH.value] = self.zenith_mesh
-        else:
-            base[RequestField.MESH.value] = self.mesh
-        return base
 
 
 @dataclass

--- a/src/server/services/remote/contracts/obstruction_contracts.py
+++ b/src/server/services/remote/contracts/obstruction_contracts.py
@@ -35,8 +35,16 @@ class ObstructionRequest(RemoteServiceRequest):
         Returns:
             List of ObstructionRequest instances (one per window)
         """
-        horizon_mesh = content.get(RequestField.HORIZON_MESH.value)
-        zenith_mesh = content.get(RequestField.ZENITH_MESH.value)
+        # Extract meshes from nested format: {"mesh": {"horizon": [...], "zenith": [...]}}
+        mesh_data = content.get(RequestField.MESH.value, {})
+        if isinstance(mesh_data, dict):
+            horizon_mesh = mesh_data.get("horizon")
+            zenith_mesh = mesh_data.get("zenith")
+            mesh = []
+        else:
+            horizon_mesh = None
+            zenith_mesh = None
+            mesh = mesh_data
 
         # Check if this is a simple single-window request
         if RequestField.X.value in content:
@@ -45,7 +53,7 @@ class ObstructionRequest(RemoteServiceRequest):
                 y=content.get(RequestField.Y.value, 0.0),
                 z=content.get(RequestField.Z.value, 0.0),
                 direction_angle=content.get(RequestField.DIRECTION_ANGLE.value, 0.0),
-                mesh=content.get(RequestField.MESH.value, []),
+                mesh=mesh,
                 horizon_mesh=horizon_mesh,
                 zenith_mesh=zenith_mesh,
             )]
@@ -53,7 +61,6 @@ class ObstructionRequest(RemoteServiceRequest):
         # Otherwise, extract from reference_point and direction_angle responses
         reference_points = content.get(RequestField.REFERENCE_POINT.value, {})
         direction_angles = content.get(RequestField.DIRECTION_ANGLE.value, {})
-        mesh = content.get(RequestField.MESH.value, [])
 
         requests = []
         for window_name, ref_point in reference_points.items():
@@ -73,17 +80,20 @@ class ObstructionRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        # Obstruction service only understands 'mesh' - combine split meshes if present
-        combined_mesh = self.mesh
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
-        return {
+        result = {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-            RequestField.MESH.value: combined_mesh,
         }
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            result[RequestField.MESH.value] = {
+                "horizon": self.horizon_mesh or [],
+                "zenith": self.zenith_mesh or [],
+            }
+        else:
+            result[RequestField.MESH.value] = self.mesh
+        return result
 
 
 @dataclass
@@ -106,16 +116,17 @@ class ObstructionMultiRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        combined_mesh = self.mesh
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
+            mesh_value = {"horizon": self.horizon_mesh or [], "zenith": self.zenith_mesh or []}
+        else:
+            mesh_value = self.mesh
         return self._build_dict(
             **{
                 RequestField.X.value: self.x,
                 RequestField.Y.value: self.y,
                 RequestField.Z.value: self.z,
                 RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-                RequestField.MESH.value: combined_mesh,
+                RequestField.MESH.value: mesh_value,
                 RequestField.START_ANGLE.value: self.start_angle,
                 RequestField.END_ANGLE.value: self.end_angle,
                 RequestField.NUM_DIRECTIONS.value: self.num_directions
@@ -140,16 +151,20 @@ class ObstructionParallelRequest(RemoteServiceRequest):
 
     @property
     def to_dict(self) -> Dict[str, Any]:
-        combined_mesh = self.mesh
-        if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            combined_mesh = (self.horizon_mesh or []) + (self.zenith_mesh or [])
-        return {
+        result = {
             RequestField.X.value: self.x,
             RequestField.Y.value: self.y,
             RequestField.Z.value: self.z,
             RequestField.DIRECTION_ANGLE.value: self.direction_angle,
-            RequestField.MESH.value: combined_mesh,
         }
+        if self.horizon_mesh is not None or self.zenith_mesh is not None:
+            result[RequestField.MESH.value] = {
+                "horizon": self.horizon_mesh or [],
+                "zenith": self.zenith_mesh or [],
+            }
+        else:
+            result[RequestField.MESH.value] = self.mesh
+        return result
 
 
 @dataclass

--- a/src/server/services/remote/contracts/obstruction_contracts.py
+++ b/src/server/services/remote/contracts/obstruction_contracts.py
@@ -38,8 +38,8 @@ class ObstructionRequest(RemoteServiceRequest):
         # Extract meshes from nested format: {"mesh": {"horizon": [...], "zenith": [...]}}
         mesh_data = content.get(RequestField.MESH.value, {})
         if isinstance(mesh_data, dict):
-            horizon_mesh = mesh_data.get("horizon")
-            zenith_mesh = mesh_data.get("zenith")
+            horizon_mesh = mesh_data.get(RequestField.HORIZON.value)
+            zenith_mesh = mesh_data.get(RequestField.ZENITH.value)
             mesh = []
         else:
             horizon_mesh = None
@@ -88,8 +88,8 @@ class ObstructionRequest(RemoteServiceRequest):
         }
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
             result[RequestField.MESH.value] = {
-                "horizon": self.horizon_mesh or [],
-                "zenith": self.zenith_mesh or [],
+                RequestField.HORIZON.value: self.horizon_mesh or [],
+                RequestField.ZENITH.value: self.zenith_mesh or [],
             }
         else:
             result[RequestField.MESH.value] = self.mesh
@@ -117,7 +117,7 @@ class ObstructionMultiRequest(RemoteServiceRequest):
     @property
     def to_dict(self) -> Dict[str, Any]:
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
-            mesh_value = {"horizon": self.horizon_mesh or [], "zenith": self.zenith_mesh or []}
+            mesh_value = {RequestField.HORIZON.value: self.horizon_mesh or [], RequestField.ZENITH.value: self.zenith_mesh or []}
         else:
             mesh_value = self.mesh
         return self._build_dict(
@@ -159,8 +159,8 @@ class ObstructionParallelRequest(RemoteServiceRequest):
         }
         if self.horizon_mesh is not None or self.zenith_mesh is not None:
             result[RequestField.MESH.value] = {
-                "horizon": self.horizon_mesh or [],
-                "zenith": self.zenith_mesh or [],
+                RequestField.HORIZON.value: self.horizon_mesh or [],
+                RequestField.ZENITH.value: self.zenith_mesh or [],
             }
         else:
             result[RequestField.MESH.value] = self.mesh

--- a/src/server/services/remote/remote_requests.py
+++ b/src/server/services/remote/remote_requests.py
@@ -197,7 +197,7 @@ class MainRequest(RemoteServiceRequest):
     """Request for obstruction angle calculations"""
     model_type: str
     params: Parameters
-    mesh: list
+    mesh: dict
     result: Any = None
 
     @property
@@ -235,7 +235,7 @@ class ObstructionRequest(RemoteServiceRequest):
     y: float
     z: float
     direction_angle: float
-    mesh: List[List[float]]
+    mesh: dict
     window_name: str = "window"  # Store window name for response mapping
 
     @classmethod
@@ -312,7 +312,7 @@ class ObstructionMultiRequest(RemoteServiceRequest):
     y: float
     z: float
     direction_angle: float
-    mesh: List[List[float]]
+    mesh: dict
     start_angle: Optional[float] = None
     end_angle: Optional[float] = None
     num_directions: Optional[int] = None
@@ -344,7 +344,7 @@ class ObstructionParallelRequest(RemoteServiceRequest):
     y: float
     z: float
     direction_angle: float
-    mesh: List[List[float]]
+    mesh: dict
 
     @property
     def to_dict(self) -> Dict[str, Any]:

--- a/src/server/services/remote/remote_requests.py
+++ b/src/server/services/remote/remote_requests.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Dict, Any, Optional, List
+import logging
 import numpy as np
+
+logger = logging.getLogger("logger")
 
 from src.server.services.helpers.parameter_validator import ParameterValidator
 from ...enums import RequestField
@@ -536,7 +539,7 @@ class MergerRequest(RemoteServiceRequest):
         windows_dict = params.get(RequestField.WINDOWS.value, {})
         direction_angles_dict = content.get(RequestField.DIRECTION_ANGLE.value, {})
 
-        print(direction_angles_dict)
+        logger.debug("Direction angles: %s", direction_angles_dict)
 
         windows = {}
         for window_name, window_data in windows_dict.items():


### PR DESCRIPTION
## Summary
- Accept flat mesh list format (`mesh: number[][]`) in addition to split `{horizon, zenith}` format
- Add `debug_mode` flag to conditionally include individual window predictions in `/run` response
- Replace magic strings with enum members across orchestration services
- Simplify obstruction contracts for split mesh support

## Test plan
- [ ] Run simulation with flat mesh payload — verify results match split mesh
- [ ] Enable debug mode — verify per-window predictions included in response
- [ ] Run `/encode` endpoint — verify encoded images returned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)