### PR TITLE
fix: use external reference point in OBSTRUCTION_ALL pipeline

### DIFF
--- a/src/server/services/remote/contracts/external_reference_point_contracts.py
+++ b/src/server/services/remote/contracts/external_reference_point_contracts.py
@@ -91,5 +91,6 @@ class ExternalReferencePointResponse(StandardResponse):
     @property
     def to_dict(self) -> Dict[str, Any]:
         return {
-            RequestField.EXTERNAL_REFERENCE_POINT.value: self.external_reference_point
+            RequestField.EXTERNAL_REFERENCE_POINT.value: self.external_reference_point,
+            RequestField.REFERENCE_POINT.value: self.external_reference_point
         }

--- a/src/server/services/remote/contracts/obstruction_contracts.py
+++ b/src/server/services/remote/contracts/obstruction_contracts.py
@@ -34,7 +34,10 @@ class ObstructionRequest(RemoteServiceRequest):
                 mesh=mesh,
             )]
 
-        reference_points = content.get(RequestField.REFERENCE_POINT.value, {})
+        reference_points = content.get(RequestField.EXTERNAL_REFERENCE_POINT.value, {})
+        if not reference_points:
+            reference_points = content.get(RequestField.REFERENCE_POINT.value, {})
+        
         direction_angles = content.get(RequestField.DIRECTION_ANGLE.value, {})
 
         requests = []

--- a/src/server/services/remote/service_map.py
+++ b/src/server/services/remote/service_map.py
@@ -32,7 +32,7 @@ class EndpointServiceMap(StandardMap):
         EndpointType.OBSTRUCTION: [ObstructionService],
         EndpointType.OBSTRUCTION_PARALLEL: [ObstructionService],
         EndpointType.OBSTRUCTION_MULTI: [ObstructionService],
-        EndpointType.OBSTRUCTION_ALL: [ReferencePointService, DirectionAngleService, ObstructionService],
+        EndpointType.OBSTRUCTION_ALL: [ReferencePointService, DirectionAngleService, ExternalReferencePointService, ObstructionService],
         EndpointType.HORIZON: [ObstructionService],
         EndpointType.ZENITH: [ObstructionService],
         EndpointType.SIMULATE: [ModelService],


### PR DESCRIPTION
OBSTRUCTION_ALL pipeline is missing ExternalReferencePointService, causing obstruction calculations to use the internal window reference point (room boundary side) instead of the external face of the window.

### Summary
- Add ExternalReferencePointService to OBSTRUCTION_ALL service chain in service_map.py
- Update ObstructionRequest.parse() to prefer external_reference_point over reference_point, with fallback to internal point
- Add reference_point alias in ExternalReferencePointResponse.to_dict for downstream compatibility


