### PR TITLE
Avoid recursive float rounding

### DIFF
--- a/src/server/services/helpers/logging_utils.py
+++ b/src/server/services/helpers/logging_utils.py
@@ -223,12 +223,8 @@ class LoggingDictFormatter(ILoggingFormatter):
         formatted = {}
         for key, value in data.items():
             if LengthReplacementStrategy.should_trim(key):
-                # Direct trim keys - format as summary, but round if it's coordinate data
-                if LengthReplacementStrategy.should_round_coordinates(key):
-                    rounded_value = LengthReplacementStrategy._round_nested_floats(value)
-                    formatted[key] = LengthReplacementStrategy.format_value(rounded_value)
-                else:
-                    formatted[key] = LengthReplacementStrategy.format_value(value)
+                # Direct trim keys - format as summary (first element is already rounded in format_value)
+                formatted[key] = LengthReplacementStrategy.format_value(value)
             elif LengthReplacementStrategy.should_trim_list(key) and isinstance(value, (list, tuple)):
                 # Special keys like results - trim list to first item only
                 if len(value) > 0:

--- a/src/server/services/helpers/logging_utils.py
+++ b/src/server/services/helpers/logging_utils.py
@@ -223,7 +223,7 @@ class LoggingDictFormatter(ILoggingFormatter):
         formatted = {}
         for key, value in data.items():
             if LengthReplacementStrategy.should_trim(key):
-                # Direct trim keys - format as summary (first element is already rounded in format_value)
+                # Direct trim keys - format as summary without traversing the full payload.
                 formatted[key] = LengthReplacementStrategy.format_value(value)
             elif LengthReplacementStrategy.should_trim_list(key) and isinstance(value, (list, tuple)):
                 # Special keys like results - trim list to first item only

--- a/tests/server/services/helpers/test_logging_utils.py
+++ b/tests/server/services/helpers/test_logging_utils.py
@@ -1,0 +1,27 @@
+from src.server.services.helpers.logging_utils import (
+    LengthReplacementStrategy,
+    LoggingDictFormatter,
+)
+
+
+def test_trimmed_mesh_is_summarized_with_rounded_first_value():
+    payload = {"mesh": [[1.23456, 2.34567], [3.45678, 4.56789]]}
+
+    result = LoggingDictFormatter().format(payload)
+
+    assert result == {"mesh": "<list of 2 items, first=1.23>"}
+
+
+def test_trimmed_coordinate_payload_does_not_call_recursive_rounding(monkeypatch):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("recursive rounding should not run for trimmed payloads")
+
+    monkeypatch.setattr(
+        LengthReplacementStrategy,
+        "_round_nested_floats",
+        fail_if_called,
+    )
+
+    result = LoggingDictFormatter().format({"mesh": [[1.23456, 2.34567]]})
+
+    assert result == {"mesh": "<list of 1 items, first=1.23>"}


### PR DESCRIPTION
  - Avoid recursive float rounding for large payloads that are only logged as summaries
  - Add unit tests covering trimmed mesh formatting and guarding against recursive rounding regressions