### PR TITLE
harden /run against malformed / concurrent merge inputs

### DIFF
--- a/src/server/exceptions.py
+++ b/src/server/exceptions.py
@@ -77,6 +77,22 @@ class ServiceResponseError(ServiceException):
         return f"HTTP {self.status_code} - Service: {self.service_name}, Endpoint: {self.endpoint}, Error: {self.error_message}"
 
 
+class MergeValidationError(ServiceException):
+    """Exception raised when the per-window data assembled for the merge step is
+    inconsistent (e.g. a window is missing its simulation, or a mask has an
+    unexpected shape such as a 4-channel encoder image instead of a 2D mask).
+
+    Indicates corrupted intermediate state (e.g. from a concurrency defect) -
+    we fail loudly instead of silently producing a wrong daylight field.
+    """
+
+    def __init__(self, message: str):
+        super().__init__(message, service_name="main")
+
+    def get_log_message(self) -> str:
+        return f"Merge input validation failed: {self.message}"
+
+
 class ServiceAuthorizationError(ServiceException):
     """Exception raised when service returns 403 Forbidden (missing or invalid authorization)"""
 

--- a/src/server/services/http_client.py
+++ b/src/server/services/http_client.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any, Optional
 import logging
+import threading
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -15,7 +16,18 @@ class HTTPClient:
         self._timeout = timeout
         self._max_retries = max_retries
         self._backoff_factor = backoff_factor
-        self._session: requests.Session | None = None
+        # Sessions are thread-local: a requests.Session is not safe to share
+        # across threads. Under gunicorn (--threads N) and the per-window
+        # fan-out, a single shared session caused cross-request/window data
+        # contamination. Each thread gets its own session (keep-alive preserved).
+        self._local = threading.local()
+
+    def _get_session(self) -> requests.Session:
+        session = getattr(self._local, "session", None)
+        if session is None:
+            session = self._create_session()
+            self._local.session = session
+        return session
 
     def _create_session(self) -> requests.Session:
         session = requests.Session()
@@ -104,9 +116,8 @@ class HTTPClient:
 
     def get(self, url: str, params: Optional[Dict[str, Any]] = None) -> Dict[str, Any] | None:
         try:
-            if self._session is None:
-                self._session = self._create_session()
-            response = self._session.get(
+            session = self._get_session()
+            response = session.get(
                 url,
                 params=params,
                 timeout=(10, self._timeout)
@@ -120,9 +131,8 @@ class HTTPClient:
 
     def post(self, url: str, data: Dict[str, Any]) -> Dict[str, Any] | None:
         try:
-            if self._session is None:
-                self._session = self._create_session()
-            response = self._session.post(
+            session = self._get_session()
+            response = session.post(
                 url,
                 json=data,
                 headers={"Content-Type": "application/json"},
@@ -147,10 +157,9 @@ class HTTPClient:
         try:
             logger.info(f"POST multipart request to {url} (timeout: {self._timeout}s)")
 
-            if self._session is None:
-                self._session = self._create_session()
+            session = self._get_session()
 
-            response = self._session.post(
+            response = session.post(
                 url,
                 files=files,
                 data=data,
@@ -165,9 +174,8 @@ class HTTPClient:
 
     def post_binary(self, url: str, data: Dict[str, Any]) -> bytes | None:
         try:
-            if self._session is None:
-                self._session = self._create_session()
-            response = self._session.post(
+            session = self._get_session()
+            response = session.post(
                 url,
                 json=data,
                 headers={"Content-Type": "application/json"},

--- a/src/server/services/orchestration/encode_orchestration_service.py
+++ b/src/server/services/orchestration/encode_orchestration_service.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any
 import logging
+import numpy as np
 
 from src.server.services.remote.contracts import MergerRequest
 from src.server.services.remote.contracts.merger_contracts import MergerResponse
@@ -12,6 +13,9 @@ from ...enums import EndpointType, RequestField, ResponseKey
 from ..remote.service_map import ServiceEndpointMap
 from ...maps import StandardMap
 from ...interfaces.orchestration_interfaces import IOrchestrator
+from ...exceptions import MergeValidationError
+
+logger = logging.getLogger("logger")
 
 
 class SimulationOrchestrator(IOrchestrator):
@@ -43,6 +47,8 @@ class SimulationOrchestrator(IOrchestrator):
 
         merged_data = self._merge_window_results(request_data, window_results)
 
+        self._validate_merge_inputs(merged_data)
+
         merger_result = self._call_merger_service(merged_data, file)
 
         detailed = endpoint == EndpointType.RUN_DETAILED
@@ -53,6 +59,41 @@ class SimulationOrchestrator(IOrchestrator):
         """Merge results from all window processing"""
         merger = ResultMerger(request_data)
         return merger.merge_window_results(window_results)
+
+    def _validate_merge_inputs(self, merged_data: Dict[str, Any]) -> None:
+        """Validate the per-window data assembled for the merge step.
+
+        Guards against corrupted intermediate state (e.g. caused by a
+        concurrency defect mixing data between requests/windows): every window
+        must have a non-empty simulation and a 2D mask. On any violation we
+        raise MergeValidationError instead of silently sending a malformed
+        request to the merger (which would produce a wrong/degraded field or a
+        downstream 400).
+        """
+        params = merged_data.get(RequestField.PARAMETERS.value, {})
+        windows = params.get(RequestField.WINDOWS.value, {})
+        simulations = merged_data.get('simulations', {})
+        masks = merged_data.get(RequestField.MASK.value, {})
+
+        for window_name in windows:
+            simulation = simulations.get(window_name)
+            sim_arr = np.asarray(simulation) if simulation is not None else None
+            if sim_arr is None or sim_arr.size == 0:
+                raise MergeValidationError(
+                    f"window '{window_name}' has no simulation result"
+                )
+
+            mask = masks.get(window_name)
+            if mask is None:
+                raise MergeValidationError(
+                    f"window '{window_name}' has no mask"
+                )
+            mask_arr = np.asarray(mask)
+            if mask_arr.ndim != 2:
+                raise MergeValidationError(
+                    f"window '{window_name}' mask must be 2D, got "
+                    f"{mask_arr.ndim}D with shape {mask_arr.shape}"
+                )
 
     def _call_merger_service(self, merged_data: Dict[str, Any], file: Any) -> 'MergerResponse':
         """Call merger service with merged window data"""


### PR DESCRIPTION
### Context
Defense-in-depth for the non-deterministic `/run` daylight bug. The root cause lived in
`server_encoder` (shared stateful singletons, fixed separately). This PR ensures a
corrupted intermediate can never again *silently* produce a wrong field, and removes a
shared HTTP session across threads.

### Changes
- **Validate per-window merge inputs** before calling the merger: every window must have
  a non-empty simulation and a **2D** mask; otherwise raise `MergeValidationError`
  (clean error response) instead of silently sending a malformed request / producing a
  wrong field. Directly catches the observed `(128,128,4)`-mask symptom.
- **Thread-local `requests.Session`** in `HTTPClient`: a single shared session is not safe
  across gunicorn threads / the per-window fan-out. Each thread now owns its session
  (keep-alive preserved); also removes the lazy-init race.

### Effect
Failures become loud and retryable instead of silently wrong; the HTTP transport no
longer shares a session across threads.

### Testing
Verified together with the encoder fix: 30 concurrent `/run` → **0 failures, identical
results**.